### PR TITLE
Update old link to tails to tails.net, from tails.baum.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ a.button {
 <div id="howtouse">
   <h2>How to use it</h2>
 
-  <a href="https://torproject.org/" class="button">GET TOR BROWSER BUNDLE</a> or <a href="https://tails.boum.org/" class="button">GET TAILS LIVE DVD</a>
+  <a href="https://torproject.org/" class="button">GET TOR BROWSER BUNDLE</a> or <a href="https://tails.net/" class="button">GET TAILS LIVE DVD</a>
 <br />
 <br />
 <br />

--- a/index2.html
+++ b/index2.html
@@ -38,7 +38,7 @@
         <li>Download and install software to access the Tor network: <a href="https://torproject.org/">https://www.torproject.org</a>.
 
         <br><br>
-        For security reasons, we advise you, especially if you are uploading documents, not to use your home or work network, but instead to use a public Wi-Fi network in an  area where your screen is not visible to security cameras. Alternately, you can start up your computer from a USB key loaded with the Tails secure operating system, which is available at <a href="https://tails.boum.org/"> https://tails.boum.org </a> and includes the Tor web browser.
+        For security reasons, we advise you, especially if you are uploading documents, not to use your home or work network, but instead to use a public Wi-Fi network in an  area where your screen is not visible to security cameras. Alternately, you can start up your computer from a USB key loaded with the Tails secure operating system, which is available at <a href="https://tails.net/"> https://tails.net </a> and includes the Tor web browser.
         </li>
         <li>Once you launch the Tor browser, copy and paste the URL <strong class="onion-url">33y6fjyhs3phzfjj.onion</strong> into the Tor address bar. When the page loads, you will find further instructions on how to submit files and messages to the Guardian.</li>
 


### PR DESCRIPTION
## What does this change?

Tails now lives at tails.net, rather than the old tails.baum.org url. 